### PR TITLE
Added optional "includedUsers" and "includedChannels" config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ To use multiple Slack workspaces.
 }]
 ```
 
+To enable a specific list of channels or users.
+
+```
+"slack.workspaces": [{
+    "token": "<workspace 1 token>",
+    "includedUsers": [
+        "userName1",
+        "userName2"
+    ],
+    "includedChannels": [
+        "channelName1",
+        "channelName2"
+    ]
+}]
+```
+
 *   `slack.token *(DEPRECATED)*`  
     Use the above slack.workspaces instead.
 *   `slack.actionNotificationDisplayTime`  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode2slack",
-    "version": "1.1.1",
+    "version": "1.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -158,6 +158,20 @@
                     "default": [],
                     "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1' }, {'token':'token2'}",
                     "scope": "window"
+                },
+                "slack.includedUsers": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "default": [],
+                    "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1' }, {'token':'token2'}",
+                    "scope": "window"
+                },
+                "slack.includedChannels": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "default": [],
+                    "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1' }, {'token':'token2'}",
+                    "scope": "window"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -156,21 +156,7 @@
                     "type": "array",
                     "uniqueItems": true,
                     "default": [],
-                    "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1' }, {'token':'token2'}",
-                    "scope": "window"
-                },
-                "slack.includedUsers": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "default": [],
-                    "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1' }, {'token':'token2'}",
-                    "scope": "window"
-                },
-                "slack.includedChannels": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "default": [],
-                    "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1' }, {'token':'token2'}",
+                    "description": "Your Slack workspace(s) settings. Array of objects. E.g. { 'token':'token1', 'includedUsers': ['userName'], 'includedChannels': ['channelName'] }, {'token':'token2', , 'includedUsers': ['userName'], 'includedChannels': ['channelName']}",
                     "scope": "window"
                 }
             }

--- a/src/ApiService.ts
+++ b/src/ApiService.ts
@@ -103,8 +103,11 @@ export class ApiService {
                 //Sort the public and private channels from a-z
                 const regularChannels: any[] = conversations.channels
                     .filter(x => x.is_group === false)
+                    .filter(x => data.includedChannels.indexOf(x.name) > -1)
                     .sort((a, b) => a.name.localeCompare(b.name));
-                const npims: any[] = conversations.channels.filter(x => x.is_group === true);
+                const npims: any[] = conversations.channels
+                    .filter(x => x.is_group === true)
+                    .filter(x => data.includedChannels.indexOf(x.name) > -1);
                 const sortedChannels = regularChannels.concat(npims);
 
                 sortedChannels.forEach(channel => {
@@ -119,11 +122,13 @@ export class ApiService {
             if (users.ok !== false && users.members.length > 0) {
                 const notDeactivatedUsers: any[] = users.members.filter(user => user.deleted !== true);
                 notDeactivatedUsers.forEach(user => {
-                    channelList.push({
-                        id: user.id,
-                        label: `@${user.profile.display_name}`,
-                        description: user.profile.real_name
-                    });
+                    if(data.includedUsers.indexOf(user.name) > -1) {
+                        channelList.push({
+                            id: user.id,
+                            label: `@${user.profile.display_name}`,
+                            description: user.profile.real_name
+                        });
+                    }
                 });
             }
         } catch (error) {

--- a/src/ApiService.ts
+++ b/src/ApiService.ts
@@ -103,11 +103,11 @@ export class ApiService {
                 //Sort the public and private channels from a-z
                 const regularChannels: any[] = conversations.channels
                     .filter(x => x.is_group === false)
-                    .filter(x => data.includedChannels.indexOf(x.name) > -1)
+                    .filter(x => typeof data.includedChannels === 'undefined' || data.includedChannels.indexOf(x.name) > -1)
                     .sort((a, b) => a.name.localeCompare(b.name));
                 const npims: any[] = conversations.channels
                     .filter(x => x.is_group === true)
-                    .filter(x => data.includedChannels.indexOf(x.name) > -1);
+                    .filter(x => typeof data.includedChannels === 'undefined' || data.includedChannels.indexOf(x.name) > -1);
                 const sortedChannels = regularChannels.concat(npims);
 
                 sortedChannels.forEach(channel => {
@@ -122,7 +122,7 @@ export class ApiService {
             if (users.ok !== false && users.members.length > 0) {
                 const notDeactivatedUsers: any[] = users.members.filter(user => user.deleted !== true);
                 notDeactivatedUsers.forEach(user => {
-                    if(data.includedUsers.indexOf(user.name) > -1) {
+                    if(typeof data.includedUsers === 'undefined' || data.includedUsers.indexOf(user.name) > -1) {
                         channelList.push({
                             id: user.id,
                             label: `@${user.profile.display_name}`,
@@ -166,7 +166,7 @@ export class ApiService {
                         id: teamResponse.team.id,
                         label: teamResponse.team.name,
                         description: teamResponse.team.domain + ".slack.com",
-                        token: tokens[i]
+                        workspace: workspaces[i]
                     });
                 }
             }

--- a/src/Slack.ts
+++ b/src/Slack.ts
@@ -12,6 +12,8 @@ export class Slack {
     private status: SetStatusBarMessage;
     private token: string;
     private workspaces: Workspace[];
+    private includedChannels: String[];
+    private includedUsers: String[];
 
     public async sendMessage(): Promise<void> {
         if (!this.isTokenPresent()) {
@@ -120,6 +122,8 @@ export class Slack {
         const config = workspace.getConfiguration("slack");
         this.token = config.get("token");
         this.workspaces = config.get("workspaces");
+        this.includedChannels = config.get("includedChannels");
+        this.includedUsers = config.get("includedUsers");
 
         if (this.isTokenPresent()) {
             const actionNotificationDisplayTime: number = config.get("actionNotificationDisplayTime", 5000);
@@ -167,8 +171,9 @@ export class Slack {
     }
 
     private async pickChannel(apiUrl: ApiUrls, data: any): Promise<void> {
+        console.log(this.includedChannels);  
         window
-            .showQuickPick(await this.api.getChannelList({ token: data.token }), {
+            .showQuickPick(await this.api.getChannelList({ token: data.token, includedChannels: this.includedChannels, includedUsers: this.includedUsers }), {
                 matchOnDescription: true,
                 placeHolder: Messages.SelectChannelPlaceHolder
             })

--- a/src/Slack.ts
+++ b/src/Slack.ts
@@ -12,6 +12,7 @@ export class Slack {
     private status: SetStatusBarMessage;
     private token: string;
     private workspaces: Workspace[];
+    private workspace: Workspace;
     private includedChannels: String[];
     private includedUsers: String[];
 
@@ -29,7 +30,7 @@ export class Slack {
 
                 const data = {
                     text: message,
-                    token: await this.getToken()
+                    ...await this.getWorkspace()
                 };
                 this.chooseAction(ApiUrls.PostText, data);
             }
@@ -57,7 +58,7 @@ export class Slack {
 
             const data = {
                 text: selectedText,
-                token: await this.getToken()
+                ...await this.getWorkspace()
             };
             this.chooseAction(ApiUrls.PostText, data);
         } else {
@@ -78,7 +79,7 @@ export class Slack {
 
                 const data = {
                     num_minutes: minutes,
-                    token: await this.getToken()
+                    ...await this.getWorkspace()
                 };
 
                 this.chooseAction(ApiUrls.SetSnooze, data);
@@ -92,7 +93,7 @@ export class Slack {
         if (!this.isTokenPresent()) {
             return;
         }
-        this.chooseAction(ApiUrls.EndSnooze, { token: await this.getToken() });
+        this.chooseAction(ApiUrls.EndSnooze, await this.getWorkspace());
     }
 
     public async dndInfo() {
@@ -100,7 +101,7 @@ export class Slack {
             return;
         }
 
-        this.chooseAction(ApiUrls.DndInfo, { token: await this.getToken() });
+        this.chooseAction(ApiUrls.DndInfo, await this.getWorkspace());
     }
 
     public async uploadSelectedFile(uri): Promise<void> {
@@ -121,9 +122,8 @@ export class Slack {
     public updateSettings(): void {
         const config = workspace.getConfiguration("slack");
         this.token = config.get("token");
+        this.workspace = config.get("workspace");
         this.workspaces = config.get("workspaces");
-        this.includedChannels = config.get("includedChannels");
-        this.includedUsers = config.get("includedUsers");
 
         if (this.isTokenPresent()) {
             const actionNotificationDisplayTime: number = config.get("actionNotificationDisplayTime", 5000);
@@ -138,13 +138,19 @@ export class Slack {
         }
     }
 
-    private async getToken(): Promise<string> {
-        let token: string = "";
+    private async getWorkspace(): Promise<Workspace> {
+        let workspace: Workspace = {
+            token: '',
+            includedChannels: [],
+            includedUsers: []
+        };
 
-        if (this.token) {
-            token = this.token;
+        if (this.workspace) {
+            workspace = this.workspace;
+        } else if(this.token) {
+            workspace.token = this.token;
         } else if (this.workspaces.length === 1) {
-            token = this.workspaces[0].token;
+            workspace = this.workspaces[0];
         } else {
             await window
                 .showQuickPick(await this.api.getTeams(this.workspaces), {
@@ -153,13 +159,13 @@ export class Slack {
                 })
                 .then(team => {
                     if (!team) {
-                        return;
+                        return {};
                     }
 
-                    token = team.token;
+                    workspace = team.workspace;
                 });
         }
-        return token;
+        return workspace;
     }
 
     private async chooseAction(apiUrl: ApiUrls, data: any): Promise<void> {
@@ -171,9 +177,12 @@ export class Slack {
     }
 
     private async pickChannel(apiUrl: ApiUrls, data: any): Promise<void> {
-        console.log(this.includedChannels);  
         window
-            .showQuickPick(await this.api.getChannelList({ token: data.token, includedChannels: this.includedChannels, includedUsers: this.includedUsers }), {
+            .showQuickPick(await this.api.getChannelList({
+                token: data.token,
+                includedChannels: data.includedChannels,
+                includedUsers: data.includedUsers
+            }), {
                 matchOnDescription: true,
                 placeHolder: Messages.SelectChannelPlaceHolder
             })
@@ -217,9 +226,9 @@ export class Slack {
             const fileName = filenameWithPath.substring(filenameWithPath.lastIndexOf("\\") + 1);
             const file = fs.createReadStream(filenameWithPath);
             const data = {
-                token: await this.getToken(),
                 filename: fileName,
-                file: file
+                file: file,
+                ...await this.getWorkspace(),
             };
 
             this.chooseAction(ApiUrls.UploadFiles, data);

--- a/src/interfaces/Interfaces.ts
+++ b/src/interfaces/Interfaces.ts
@@ -37,7 +37,7 @@ export interface Team {
     id: string;
     label: string;
     description: string;
-    token: string;
+    workspace: Workspace;
 }
 
 export interface TeamsResponse extends Result {
@@ -49,4 +49,6 @@ export interface TeamsResponse extends Result {
 }
 export interface Workspace {
     token: string;
+    includedChannels: Array<string>;
+    includedUsers: Array<string>;
 }


### PR DESCRIPTION
When using this integration, I often had the worry that I would send a message out company-wide via the announcements by pressing enter too rapidly. As such, I added the configuration option to have "includedChannels" and "includedUsers" which allows you to define an array of channels or users that will be available in the selection dropdown. If a list is left undefined in the vscode config, the entire list will be displayed as it currently behaves.